### PR TITLE
Add GitHub Copilot extensions to codespace setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,8 @@
 ln -s /workspaces/.codespaces/.persistedshare/dotfiles/git/.gitconfig ~/.gitconfig
 
+# Install GitHub Copilot VS Code extensions
+code --install-extension GitHub.copilot
+code --install-extension GitHub.copilot-chat
+
 # Update package information
 sudo apt update -y


### PR DESCRIPTION
The `devcontainer.json` in the main development branch cannot be modified to include Copilot extensions. This change works around that limitation by installing the extensions via the dotfiles `install.sh` script, which runs automatically when a codespace is created.

The script now calls `code --install-extension` for `GitHub.copilot` and `GitHub.copilot-chat`, giving every codespace Copilot support without touching `devcontainer.json`.